### PR TITLE
[ODBC] TZQuery does not generate a change of text blob field

### DIFF
--- a/src/component/ZAbstractDataset.pas
+++ b/src/component/ZAbstractDataset.pas
@@ -913,6 +913,7 @@ var
             try
               DestStream := DestDataset.CreateBlobStream(DestField, bmWrite);
               try
+                DestStream.Size := 0;
                 DestStream.CopyFrom(SrcStream, 0);
               finally
                 DestStream.Free;


### PR DESCRIPTION
TZQuery does not generate a change of text blob field when new string length small or equal to old value

Problem in TZVarVarLenDataRefStream, CopyFrom method does no change FUpdated property, FUpdatet changes in Realloc

Workaround to change capacity to zero, because CopyFrom method not virtual in TStream 
