### PR TITLE
[ODBC] TZQuery does not generate a change of text blob field

### DIFF
--- a/src/component/ZAbstractDataset.pas
+++ b/src/component/ZAbstractDataset.pas
@@ -913,7 +913,6 @@ var
             try
               DestStream := DestDataset.CreateBlobStream(DestField, bmWrite);
               try
-                DestStream.Size := 0;
                 DestStream.CopyFrom(SrcStream, 0);
               finally
                 DestStream.Free;

--- a/src/dbc/ZDbcResultSet.pas
+++ b/src/dbc/ZDbcResultSet.pas
@@ -1409,7 +1409,8 @@ type
       const OpenLobStreams: TZSortedList);
     destructor Destroy; override;
     function Write(const Buffer; Count: Longint): Longint; override;
-  end;
+    function Write(const Buffer: TBytes; Offset, Count: Longint): Longint; overload; override;
+end;
 
   {** EH: implements a readonly stream
     use it for MySQL(store_result) or Postgres <> non single_row_mode
@@ -5338,9 +5339,17 @@ begin
   FUpdated := True;
 end;
 
+function TZVarVarLenDataRefStream.Write(const Buffer: TBytes; Offset, Count: Integer): Longint;
+begin
+  FUpdated := True;
+  Capacity := Count; // Need to realloc FVarLenDataRef.VarLenData
+  Result := inherited Write(Buffer, Offset, Count);
+end;
+
 function TZVarVarLenDataRefStream.Write(const Buffer; Count: Longint): Longint;
 begin
   FUpdated := True;
+  Capacity := Count; // Need to realloc FVarLenDataRef.VarLenData
   Result := inherited Write(Buffer, Count);
 end;
 


### PR DESCRIPTION
TZQuery does not generate a change of text blob field by TWideMemo->TWideMemoField when new string length small or equal to old value

In TZVarVarLenDataRefStream need to override second Write method, becouse TWideMemoFiled used WriteBuffer to set data:

```
procedure TBlobField.SetData(Buffer: TValueBuffer; Len: Integer);
var
  LStream: TStream;
begin
  LStream := DataSet.CreateBlobStream(Self, bmWrite);
  try
    LStream.WriteBuffer(Buffer[0], Len);
  finally
    LStream.Free;
  end;
end;

```

And TStream.WriteBuffer used Write method with three parameters:

```
procedure TStream.WriteBuffer(Buffer: TBytes; Count: Longint);
var
  LTotalCount,
    LWrittenCount: Longint;
begin
  { Perform a write directly. Most of the time this will succeed
    without the need to go into the WHILE loop. }
  LTotalCount := Write(Buffer, 0, Count);

  while (LTotalCount < Count) do
  begin
    { Try to read a contiguous block of <Count> size }
    LWrittenCount := Write(Buffer, LTotalCount,(Count - LTotalCount));

    { Check if we written something and decrease the number of bytes left to read }
    if LWrittenCount <= 0 then
      raise EWriteError.CreateRes(@SReadError)
    else
      Inc(LTotalCount, LWrittenCount);
  end;
end;

```

And in TZVarVarLenDataRefStream.Write need to realloc FVarLenDataRef.VarLenData (without set new capacity AccesViolation raised)

```
function TZVarVarLenDataRefStream.Write(const Buffer; Count: Longint): Longint;
begin
  FUpdated := True;
  Capacity := Count; // Need to realloc FVarLenDataRef.VarLenData
  Result := inherited Write(Buffer, Count);
end;
```

