### PR TITLE
CreateBlobStream with bmWrite

### DIFF
--- a/src/component/ZAbstractDataset.pas
+++ b/src/component/ZAbstractDataset.pas
@@ -913,7 +913,6 @@ var
             try
               DestStream := DestDataset.CreateBlobStream(DestField, bmWrite);
               try
-                DestStream.Size := 0;
                 DestStream.CopyFrom(SrcStream, 0);
               finally
                 DestStream.Free;

--- a/src/component/ZAbstractRODataset.pas
+++ b/src/component/ZAbstractRODataset.pas
@@ -5371,6 +5371,8 @@ begin
 
       if Mode <> bmRead then
         Blob.SetOnUpdateHandler(OnBlobUpdate, NativeInt(Field));
+      if Mode = bmWrite then 
+        Result.Size := 0;
     end;
   end;
 


### PR DESCRIPTION
CreateBlobStream with bWrite need to create with clear data

For example standart Delphi code

```
constructor TClientBlobStream.Create(Field: TBlobField; Mode: TBlobStreamMode);
begin
  FField := Field;
  FFieldNo := FField.FieldNo;
  FDataSet := FField.DataSet as TCustomClientDataSet;
  if Mode <> bmRead then
  begin
    if FField.ReadOnly then
      DatabaseErrorFmt(SFieldReadOnly, [FField.DisplayName], FDataSet);
    if not (FDataSet.State in [dsEdit, dsInsert, dsNewValue]) then
      DatabaseError(SNotEditing, FDataSet);
  end;
  if not FDataSet.GetActiveRecBuf(FBuffer) then Exit;
  if Mode = bmWrite then Truncate
  else ReadBlobData;
end;
```