### PR TITLE
Settings TBlobField.asString showing empty value in TDBMemo

### DIFF
--- a/src/dbc/ZDbcResultSet.pas
+++ b/src/dbc/ZDbcResultSet.pas
@@ -5299,10 +5299,10 @@ var P: Pointer;
   PA: PAnsiChar;
   Idx: Integer;
 begin
-  P := FVarLenDataRef.VarLenData;
-  FVarLenDataRef.VarLenData := nil; //do not relloc memory on destruction
   if FUpdated then
     FOwner.SetUpdated(True);
+  P := FVarLenDataRef.VarLenData;
+  FVarLenDataRef.VarLenData := nil; //do not relloc memory on destruction
   inherited; //calls realloc
   FVarLenDataRef.VarLenData := P; //the memory is owned by lob or reference
   { now add a null term for Postgres f.e.}


### PR DESCRIPTION
Because FOwner.SetUpdated(True) after FVarLenDataRef.VarLenData := nil generetes TDBMemo.DataChange event and TBlobField.asString is empty in this time
